### PR TITLE
Añadida opción para tiempo entre llamadas

### DIFF
--- a/modules/callcenter_config/themes/default/form.tpl
+++ b/modules/callcenter_config/themes/default/form.tpl
@@ -26,6 +26,8 @@
 <tr class="letra12"><td>{$asterisk_duracion_sesion.INPUT}</td></tr>
 <tr class="letra12"><td>{$dialer_forzar_sobrecolocar.LABEL}:</td></tr>
 <tr class="letra12"><td>{$dialer_forzar_sobrecolocar.INPUT}</td></tr>
+<tr class="letra12"><td>{$dialer_entretiempo.LABEL}:</td></tr>
+<tr class="letra12"><td>{$dialer_entretiempo.INPUT}</td></tr>
 </table>
 </td>
 <td valign="top">


### PR DESCRIPTION
Se agrega opción para permitir la revisión de una campaña y la ejecución de la llamada cada cierta cantidad de segundos, ya que actualmente está quemado en el código 3 segundos.