### PR TITLE
Añadida opción para tiempo entre llamadas

### DIFF
--- a/setup/dialer_process/dialer/ConfigDB.class.php
+++ b/setup/dialer_process/dialer/ConfigDB.class.php
@@ -170,7 +170,15 @@ class ConfigDB
                 'mostrar_valor' =>  TRUE,
                 'cast'          =>  'int',
             ),
-
+	    'entretiempo' => array(
+                'descripcion'   =>  'Tiempo de espera entre llamadas',
+                'regex'         =>  '^\d+$',
+                'valor_omision' =>  5,
+                'valor_viejo'   =>  NULL,
+                'valor_actual'  =>  NULL,
+                'mostrar_valor' =>  TRUE,
+                'cast'          =>  'int',
+            ),
 		),
 	);
 


### PR DESCRIPTION
Se agrega opción para permitir la revisión de una campaña y la ejecución de la llamada cada cierta cantidad de segundos, ya que actualmente está quemado en el código 3 segundos.