### PR TITLE
Añadida opción para tiempo entre llamadas

### DIFF
--- a/setup/dialer_process/dialer/CampaignProcess.class.php
+++ b/setup/dialer_process/dialer/CampaignProcess.class.php
@@ -23,7 +23,7 @@
 
 // Número mínimo de muestras para poder confiar en predicciones de marcador
 define('MIN_MUESTRAS', 10);
-define('INTERVALO_REVISION_CAMPANIAS', 3);
+//define('INTERVALO_REVISION_CAMPANIAS', 3);
 
 class CampaignProcess extends TuberiaProcess
 {
@@ -317,8 +317,11 @@ class CampaignProcess extends TuberiaProcess
     {
         // Revisar las campañas cada 3 segundos
         $iTimestamp = time();
-        if ($iTimestamp - $this->_iTimestampUltimaRevisionCampanias >= INTERVALO_REVISION_CAMPANIAS) {
-
+      	if (empty($INTERVALO_REVISION_CAMPANIAS)) {
+			      $INTERVALO_REVISION_CAMPANIAS = $this->_configDB->dialer_entretiempo;
+		    }
+		    if ($iTimestamp - $this->_iTimestampUltimaRevisionCampanias >= $INTERVALO_REVISION_CAMPANIAS) {
+        //if ($iTimestamp - $this->_iTimestampUltimaRevisionCampanias >= INTERVALO_REVISION_CAMPANIAS) {
             /* Se actualiza timestamp de revisión aquí por si no se puede
              * actualizar más tarde debido a una excepción de DB. */
             $this->_iTimestampUltimaRevisionCampanias = $iTimestamp;


### PR DESCRIPTION
Se agrega opción para permitir la revisión de una campaña y la ejecución de la llamada cada cierta cantidad de segundos, ya que actualmente está quemado en el código 3 segundos.